### PR TITLE
Add support for Symfony 6 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "psr/container": "^1.0|^2.0",
-        "symfony/options-resolver": "^4.2 || ^5.0"
+        "symfony/options-resolver": "^4.2 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8",


### PR DESCRIPTION
Adding support for Symfony 6.x option resolver component to avoid failing installs on Symfony 6.x projects.