### PR TITLE
Add support for Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     ],
     "require": {
         "psr/container": "^1.0|^2.0",
-        "symfony/options-resolver": "^4.2 || ^5.0 || ^6.0 || ^7.0"
+        "symfony/options-resolver": "^4.2 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8",
         "phpstan/phpstan": "^0.12.52",
-        "friendsofphp/php-cs-fixer": "^2.16"
+        "php-cs-fixer/shim": "^3.89"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Follows https://github.com/phpbench/phpbench/pull/1128

I didn't touch the CI as it seems pretty outdated, but locally I was able to install Symfony 8.0.0-BETA1 and run tests:
```
➜  phpbench-container git:(symfony-8) ✗ sfcp req symfony/options-resolver ^8.0.0-BETA1 -W
./composer.json has been updated
Running composer update symfony/options-resolver --with-all-dependencies
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading symfony/options-resolver (v7.3.3 => v8.0.0-BETA1)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Upgrading symfony/options-resolver (v7.3.3 => v8.0.0-BETA1): Extracting archive
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
23 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Symfony recipes are disabled: "symfony/flex" not found in the root composer.json

Synchronizing package.json is disabled: "symfony/flex" not found in the root composer.json
No security vulnerability advisories found.

➜  phpbench-container git:(symfony-8) ✗ sfp vendor/bin/php
Could not open input file: vendor/bin/php
➜  phpbench-container git:(symfony-8) ✗ sfp vendor/bin/phpunit
PHPUnit 8.5.48 by Sebastian Bergmann and contributors.

............                                                      12 / 12 (100%)

Time: 25 ms, Memory: 6.00 MB

OK (12 tests, 26 assertions)
➜  phpbench-container git:(symfony-8) ✗
```